### PR TITLE
Add documentation for dynamic include and import

### DIFF
--- a/documentation/tag/import.md
+++ b/documentation/tag/import.md
@@ -8,3 +8,11 @@ Assuming that a macro named `input` exists in a template called `form_util` you 
 
 {{ input("text", "name", "Mitchell") }}
 ```
+
+## Dynamic Import
+The `import` tag will accept an expression to determine the template to import at runtime. For example:
+```
+{% import modern ? 'ajax_form_util' : 'simple_form_util' %}
+
+{{ input("text", "name", "Mitchell") }}
+```

--- a/documentation/tag/include.md
+++ b/documentation/tag/include.md
@@ -9,3 +9,10 @@ Top Content
 Bottom Content
 {% include "footer" %}
 ```
+
+You can add additional variables to the context of the included template by passing a map after the `with` keyword. The included template will have access to the same variables that the current template does plus the additional ones defined in the map passed after the `with` keyword:
+
+```
+{% include "advertisement" with {"foo":"bar"} %}
+```
+

--- a/documentation/tag/include.md
+++ b/documentation/tag/include.md
@@ -16,3 +16,8 @@ You can add additional variables to the context of the included template by pass
 {% include "advertisement" with {"foo":"bar"} %}
 ```
 
+## Dynamic Include
+The `include` tag will accept an expression to determine the template to include at runtime. For example:
+```
+{% include admin ? 'adminFooter' : 'defaultFooter' %}
+```


### PR DESCRIPTION
While reading in the pebble code i stumbled over the possibility to pass an expression for template name in the include- and import-tags. This commit adds some documentation for this feature.