### PR TITLE
slice: describe toIndex as exclusive

### DIFF
--- a/documentation/filter/slice.md
+++ b/documentation/filter/slice.md
@@ -11,4 +11,4 @@ The `slice` filter returns a portion of a list, array, or string.
 
 ## Arguments
 - `fromIndex`: 0-based and inclusive
-- `toIndex`: 0-based and inclusive
+- `toIndex`: 0-based and exclusive


### PR DESCRIPTION
The implementation and the examples suggest that the toIndex is exclusive, not inclusive.